### PR TITLE
Changes to get bolts to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ build:
 install:
 	$(MAKE) build
 	mkdir -p ~/.bolts/
-	cp -r ./default_config/ ~/.bolts
+	cp -r ./default_config ~/.bolts
 	chmod -R a+w+r ~/.bolts
-	cp ./target/release/bolts /usr/bin/bolts
+	cp ./target/release/bolts /usr/local/bin/bolts
 
 .PHONY: build install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a rust static site generator
  $ cd /directory/for/your/project/to/be/in
  $ bolts init PROJECT_NAME
  $ cd PROJECT_NAME
- $ bolts run
+ $ sudo bolts run
 ```
 
 ### All commands:


### PR DESCRIPTION
Platform: Mac OSX
- Removed trailing "/" to copy directory and not just contents
- Copy to /usr/local/bin instead of /usr/bin
- Run "sudo bolts run" (no idea why)
